### PR TITLE
remove redundant instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,3 @@ python3 launch.py
 
 ## Citations
 <b id="f1">[1]</b> https://github.com/oarriaga/face_classification [↩](#a1)
-
-
-## GUI
-Run the following to install guizero
-```bash
-pip install guizero
-```


### PR DESCRIPTION
This is no longer needed because `requirements.txt` includes package `guizero`.