### PR TITLE
use human readable json file as database

### DIFF
--- a/theme/Theme.py
+++ b/theme/Theme.py
@@ -44,7 +44,6 @@ class Rule:
     def trigger(state):
         return False
 
-
 class TurbulanceRuleGlobal(Rule):
 
     name = 'TurbulanceRuleGlobal'

--- a/user/clear_user_database.py
+++ b/user/clear_user_database.py
@@ -1,3 +1,0 @@
-import mock_database as database
-
-database.clear()

--- a/user/inspect_user_database.py
+++ b/user/inspect_user_database.py
@@ -1,3 +1,0 @@
-import mock_database as database
-
-print(database.find())

--- a/user/mock_database.py
+++ b/user/mock_database.py
@@ -1,12 +1,14 @@
+import json
 import os
-import pickle
 
-file_path = os.path.dirname(os.path.abspath(__file__)) + '/user_database.p'
-data = pickle.load(open(file_path, 'rb'))
+file_path = os.path.dirname(os.path.abspath(__file__)) + '/user_database.json'
+with open(file_path, 'r') as fp:
+    data = json.load(fp)
 
 def save(user):
-    data[user.username] = { 'birthday': user.info.birthday, 'preference': user.info.preference, 'history': user.info.history}
-    pickle.dump(data, open(file_path, 'wb'))
+    data[user.username] = { 'birthday': user.info.birthday, 'preference': user.info.preference, 'history': user.info.history }
+    with open(file_path, 'w') as fp:
+        json.dump(data, fp)
 
 def find(username=None):
     if (username):
@@ -15,4 +17,5 @@ def find(username=None):
 
 def clear():
     data = {}
-    pickle.dump(data, open(file_path, 'wb'))
+    with open(file_path, 'w') as fp:
+        json.dump(data, fp)

--- a/user/user_database.json
+++ b/user/user_database.json
@@ -1,0 +1,1 @@
+{"ken": {"birthday": "_", "preference": {"global_theme": null, "personal_theme": "Cozy", "disabled_default_reactions": {"TurbulanceRulePersonal": true}}, "history": ["2019-08-26 15:03:29.586340 Set preference: personal_theme to Cozy.", "2019-08-26 15:03:38.048259 Manual Override: TurbulanceRulePersonal is disabled. Context: Turbulance=85."]}}


### PR DESCRIPTION
JSON file is readable and modifiable

If the size of `history` becomes a concern, we could start thinking about moving data storage to agent instead of a centralized database.